### PR TITLE
Further packaging enhancements

### DIFF
--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -711,7 +711,8 @@ if (rc == 0) {
 			GroovyObject artifactRepositoryHelpers = (GroovyObject) artifactRepositoryHelpersClass.newInstance()
 	
 			println ("** Upload package to Artifact Repository '$url'.")
-			artifactRepositoryHelpers.upload(url, tarFile as String, user, password, props.verbose.toBoolean(), httpClientVersion)
+			def tracing = (props.verbose && props.verbose.toBoolean()) ? true : false 
+			artifactRepositoryHelpers.upload(url, tarFile as String, user, password, tracing, httpClientVersion)
 		}
 	}
 }

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -66,8 +66,11 @@ def scriptDir = new File(getClass().protectionDomain.codeSource.location.path).p
 @Field def applicationDescriptor
 @Field def sbomUtilities
 @Field def rc = 0
-@Field String includeSubfolder = "include"
+
+@Field String includeSubfolder = "public"
 @Field String binSubfolder = "bin"
+@Field String internalSubfolder = "private"
+@Field def tempLoadDir
 
 def startTime = new Date()
 
@@ -90,10 +93,6 @@ if (rc != 0) {
 
 // Enable file tagging
 BuildProperties.setProperty("dbb.file.tagging", "true") // Enable dbb file tagging
-
-// Map of last level dataset qualifier to DBB CopyToHFS CopyMode.
-def copyModeMap = parseCopyModeMap(props.copyModeMap)
-
 
 // Hashmap of BuildOutput to Record
 Map<DeployableArtifact, Map> buildOutputsMap = new HashMap<DeployableArtifact, Map>()
@@ -260,8 +259,8 @@ props.buildReportOrder.each { buildReportFile ->
 						if (applicationDescriptor && output.deployType.equals("OBJ")) {
 							fileUsage = applicationDescriptorUtils.getFileUsageByType(applicationDescriptor, "Program", member)
 						}
-						// If the artifact is not an Object Deck or has no usage or its usage is not main
-						if ((output.deployType.equals("OBJ") && fileUsage && !fileUsage.equals("main")) || !output.deployType.equals("OBJ")) { 
+						// Leave OBJs with main behind
+						if ((output.deployType.equals("OBJ") && fileUsage && (fileUsage.equals("service submodule") || fileUsage.equals("internal submodule")) ) || !output.deployType.equals("OBJ")) { 
 							datasetMembersCount++
 							String file = buildRecord.getFile()
 							def dependencySetRecord = buildReport.getRecords().find {
@@ -382,7 +381,7 @@ if (rc == 0) {
 		def tarFile = "$props.workDir/${tarFileName}"
 	
 		//Create a temporary directory on zFS to copy the load modules from data sets to
-		def tempLoadDir = new File("$props.workDir/tempPackageDir")
+		tempLoadDir = new File("$props.workDir/tempPackageDir")
 		!tempLoadDir.exists() ?: tempLoadDir.deleteDir()
 		tempLoadDir.mkdirs()
 		
@@ -473,102 +472,88 @@ if (rc == 0) {
 			}				
 		}
 		
-		if (rc == 0) {	
-	
+		if (rc == 0) {
+
 			println("*** Number of build outputs to package: ${buildOutputsMap.size()}")
-		
-			println("** Copy build outputs to temporary package directory '$tempLoadDir'")
-		
-			buildOutputsMap.each { deployableArtifact, info ->
-				String container = info.get("container")
-				String owningApplication = info.get("owningApplication")
-				Record record = info.get("record")
-				PropertiesRecord propertiesRecord = info.get("propertiesRecord")
-				DependencySetRecord dependencySetRecord = info.get("dependencySetRecord")
+
+			// TODO: Add to properties
+			def shared = ["OBJ"]
+			def generated = ["GEN", "OBJ"]
+
+			println("** Copy deployable outputs to temporary package directory '$tempLoadDir/$binSubfolder'")
+			deployableOutputs = buildOutputsMap.findAll { deployableArtifact, info ->
+				!(generated.contains(deployableArtifact.deployType) || shared.contains(deployableArtifact.deployType))
+			}
+			copyArtifactsToUSS(deployableOutputs, binSubfolder)
+
+			if (applicationDescriptor) {
+
+				// build outputs that are mapped to a shared deployType and are flagged as 'service submodule' in the application descriptor
+				publicDerivedBuildOutputs = buildOutputsMap.findAll { deployableArtifact, info ->
+					fileUsage = applicationDescriptorUtils.getFileUsageByType(applicationDescriptor, "Program", deployableArtifact.file)
+					shared.contains(deployableArtifact.deployType) && fileUsage && fileUsage.equals("service submodule")
+				}
 				
-				def relativeFilePath = ""
-				if (deployableArtifact.artifactType.equals("zFSFile")) {
-						relativeFilePath = "$binSubfolder"
-				} else {
-						if (deployableArtifact.deployType.equals("OBJ")) {
-							relativeFilePath = "$includeSubfolder/bin"
-						} else {
-							relativeFilePath = "$binSubfolder/${deployableArtifact.deployType}"
-						}
+				// build outputs that are mapped to a shared deployType and are flagged as 'internal submodule' in the application descriptor
+				internalDerivedBuildOutputs = buildOutputsMap.findAll { deployableArtifact, info ->
+					fileUsage = applicationDescriptorUtils.getFileUsageByType(applicationDescriptor, "Program", deployableArtifact.file)
+					generated.contains(deployableArtifact.deployType) && fileUsage && fileUsage.equals("internal submodule")
 				}
-		
-				// define file name in USS
-				def fileName = deployableArtifact.file
-		
-				// add deployType to file name
-				if (props.addExtension && props.addExtension.toBoolean()) {
-					fileName = fileName + '.' + deployableArtifact.deployType
+				
+				println("** Copy public build outputs to temporary package directory '$tempLoadDir/$includeSubfolder'")
+				copyArtifactsToUSS(publicDerivedBuildOutputs, includeSubfolder)
+
+				println("** Copy internal outputs to temporary package directory '$tempLoadDir/$internalSubfolder'")
+				copyArtifactsToUSS(internalDerivedBuildOutputs, internalSubfolder)
+				
+				if (deployableOutputs.size() + publicDerivedBuildOutputs.size() + internalDerivedBuildOutputs.size() != buildOutputsMap.size()) {
+					println("*! [WARNING] The number of copied artifacts does not match the identified build outputs ${buildOutputsMap.size()} . Most likely files got not assigned a correct field in the application descriptor.")
 				}
-				def file = new File("$tempLoadDir/$relativeFilePath/$fileName")
-		
-				def (directory, relativeFileName) = extractDirectoryAndFile(file.toPath().toString())
-				new File(directory).mkdirs()
-		
-		
-				if (deployableArtifact.artifactType.equals("zFSFile")) {
-					def originalFile = new File(container + "/" + deployableArtifact.file)
-					println "\tCopy '${originalFile.toPath()}' to '${file.toPath()}'"
-					try {
-						Files.copy(originalFile.toPath(), file.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
-					} catch (IOException exception) {
-						println "!* [ERROR] Copy failed: an error occurred when copying '${originalFile.toPath()}' to '${file.toPath()}'"
-						rc = Math.max(rc, 1) 
+				
+				// Checks if all binary interfaces (submodules) are in the archive or not
+				checkBinaryInterfaces(tempLoadDir, applicationDescriptor)
+
+				
+				ArrayList<String> publicIncludeFiles = applicationDescriptorUtils.getFilesByTypeAndUsage(applicationDescriptor, "Include File", "public")
+				ArrayList<String> sharedIncludeFiles = applicationDescriptorUtils.getFilesByTypeAndUsage(applicationDescriptor, "Include File", "shared")
+				
+				
+				if (publicIncludeFiles && !publicIncludeFiles.isEmpty()) {
+					if (sharedIncludeFiles && !sharedIncludeFiles.isEmpty()) {
+						publicIncludeFiles.addAll(sharedIncludeFiles)
 					}
-				} else if  (deployableArtifact.artifactType.equals("DatasetMember")) {
-					// set copyMode based on last level qualifier
-					currentCopyMode = copyModeMap[container.replaceAll(/.*\.([^.]*)/, "\$1")]
-					if (currentCopyMode != null) {
-						if (ZFile.exists("//'$container(${deployableArtifact.file})'")) {
-							// Copy outputs to HFS
-							CopyToHFS copy = new CopyToHFS()
-							copy.setCopyMode(DBBConstants.CopyMode.valueOf(currentCopyMode))
-							copy.setDataset(container)
-		
-							println "\tCopy '$container(${deployableArtifact.file})' to '$tempLoadDir/$relativeFilePath/$fileName' with DBB Copymode '$currentCopyMode'"
-							copy.dataset(container).member(deployableArtifact.file).file(file).execute()
-		
-							// Tagging binary files
-							if (currentCopyMode == CopyMode.BINARY || currentCopyMode == CopyMode.LOAD) {
-								StringBuffer stdout = new StringBuffer()
-								StringBuffer stderr = new StringBuffer()
-								Process process = "chtag -b $file".execute()
-								process.waitForProcessOutput(stdout, stderr)
-								if (stderr){
-									println ("*! stderr : $stderr")
-									println ("*! stdout : $stdout")
-								}
+					
+					println("*** Number of public source code interfaces to package: ${publicIncludeFiles.size()}")
+					println("** Copy all public source code interfaces from application repository to temporary package directory '$tempLoadDir'")
+					
+					publicIncludeFiles.forEach() { includeFile ->
+						Path includeFilePath = Paths.get("${props.applicationFolderPath}/${includeFile}")
+						Path targetIncludeFilePath = Paths.get("${tempLoadDir.getPath()}/${includeSubfolder}/src/${includeFilePath.getFileName()}")
+						if (props.verbose) println("\tCopy '${includeFilePath}' file to '${targetIncludeFilePath}'")
+						try {
+							//Create target parent folder if it doesn't exist
+							def targetIncludeFilesFolder = targetIncludeFilePath.getParent().toFile()
+							if (!targetIncludeFilesFolder.exists()) {
+								targetIncludeFilesFolder.mkdirs()
 							}
-		
-							// Append record to Wazi Deploy Application Manifest
-							if (wdManifestGeneratorUtilities && props.generateWaziDeployAppManifest && props.generateWaziDeployAppManifest.toBoolean()) {
-									wdManifestGeneratorUtilities.appendArtifactToManifest(deployableArtifact, "$relativeFilePath/$fileName", record, dependencySetRecord, propertiesRecord)
-							}
-		
-						} else {
-							println "*! [ERROR] Copy failed: The file '$container(${deployableArtifact.file})' doesn't exist."
-							rc = Math.max(rc, 1) 
+							Files.copy(includeFilePath, targetIncludeFilePath, COPY_ATTRIBUTES, REPLACE_EXISTING)
+						} catch (IOException exception) {
+							println "!* [ERROR] Copy failed: an error occurred when copying '${includeFilePath}' to '${targetIncludeFilePath}'"
+							rc = Math.max(rc, 1)
 						}
-					} else {
-						println "*! [ERROR] Copy failed: The file '$container(${deployableArtifact.file})' could not be copied due to missing mapping."
-						rc = Math.max(rc, 1) 
 					}
-				} else if  (deployableArtifact.artifactType.equals("DatasetMemberDelete")) {
-						// generate delete instruction for Wazi Deploy
-						if (wdManifestGeneratorUtilities && props.generateWaziDeployAppManifest && props.generateWaziDeployAppManifest.toBoolean()) {
-							wdManifestGeneratorUtilities.appendArtifactDeletionToManifest(deployableArtifact, "$relativeFilePath/$fileName", record, propertiesRecord)
-						}
 				}
 
-
-				if (props.generateSBOM && props.generateSBOM.toBoolean() && rc == 0) {
-					sbomUtilities.addEntryToSBOM(deployableArtifact, info)
+			} else {
+				// grouping of build outputs for shared and generated source only available via Application Descriptor
+				skippedDeployableOutputs = buildOutputsMap.findAll { deployableArtifact, info ->
+					(generated.contains(deployableArtifact.deployType) || shared.contains(deployableArtifact.deployType))
+				}
+				if (skippedDeployableOutputs) {
+					println("** Number of skipped build outputs: ${skippedDeployableOutputs.size()}")
 				}
 			}
+
 		}
 		
 		if (props.generateSBOM && props.generateSBOM.toBoolean() && rc == 0) {
@@ -624,33 +609,6 @@ if (rc == 0) {
 			if (props.verbose) println("** Copy packaging properties config file to '$copiedPackagingPropertiesFilePath'")
 			Files.copy(packagingPropertiesFilePath, copiedPackagingPropertiesFilePath, COPY_ATTRIBUTES, REPLACE_EXISTING)
 	
-			if (applicationDescriptor) {
-				ArrayList<String> publicIncludeFiles = applicationDescriptorUtils.getFilesByTypeAndUsage(applicationDescriptor, "Include File", "public")
-				ArrayList<String> sharedIncludeFiles = applicationDescriptorUtils.getFilesByTypeAndUsage(applicationDescriptor, "Include File", "shared")
-				if (publicIncludeFiles && !publicIncludeFiles.isEmpty()) {
-					if (sharedIncludeFiles && !sharedIncludeFiles.isEmpty()) {
-						publicIncludeFiles.addAll(sharedIncludeFiles)
-					}
-					publicIncludeFiles.forEach() { includeFile ->
-						Path includeFilePath = Paths.get("${props.applicationFolderPath}/${includeFile}")
-						Path targetIncludeFilePath = Paths.get("${tempLoadDir.getPath()}/${includeSubfolder}/src/${includeFilePath.getFileName()}")
-						if (props.verbose) println("** Copy '${includeFilePath}' file to '${targetIncludeFilePath}'")
-						try {
-							//Create target parent folder if it doesn't exist
-							def targetIncludeFilesFolder = targetIncludeFilePath.getParent().toFile()
-							if (!targetIncludeFilesFolder.exists()) {
-								targetIncludeFilesFolder.mkdirs()
-							}								
-							Files.copy(includeFilePath, targetIncludeFilePath, COPY_ATTRIBUTES, REPLACE_EXISTING)
-						} catch (IOException exception) {
-							println "!* [ERROR] Copy failed: an error occurred when copying '${includeFilePath}' to '${targetIncludeFilePath}'"
-							rc = Math.max(rc, 1) 
-						}
-					}
-				}
-				// Checks if all binary interfaces (submodules) are in the archive or not
-				checkBinaryInterfaces(tempLoadDir, applicationDescriptor)
-			}
 			
 			if (props.owner) {
 				def processCmd = [
@@ -750,6 +708,106 @@ if (rc > 0) {
 	println ("** Packaging completed successfully.")
 }
 System.exit(rc)
+
+/**
+ * 
+ */
+
+def copyArtifactsToUSS(Map<DeployableArtifact, Map> buildOutputsMap, String tarSubfolder) {
+	// local variables 
+	def copyModeMap = parseCopyModeMap(props.copyModeMap) // Map of last level dataset qualifier to DBB CopyToHFS CopyMode.
+	
+	buildOutputsMap.each { deployableArtifact, info ->
+		String container = info.get("container")
+		String owningApplication = info.get("owningApplication")
+		Record record = info.get("record")
+		PropertiesRecord propertiesRecord = info.get("propertiesRecord")
+		DependencySetRecord dependencySetRecord = info.get("dependencySetRecord")
+		
+		def relativeFilePath = ""
+		if (deployableArtifact.artifactType.equals("zFSFile")) {
+				relativeFilePath = "$binSubfolder/uss"
+		} else {
+				if (deployableArtifact.deployType.equals("OBJ")) {
+					relativeFilePath = "$tarSubfolder/bin"
+				} else {
+					relativeFilePath = "$tarSubfolder/${deployableArtifact.deployType}"
+				}
+		}
+
+		// define file name in USS
+		def fileName = deployableArtifact.file
+
+		// add deployType to file name
+		if (props.addExtension && props.addExtension.toBoolean()) {
+			fileName = fileName + '.' + deployableArtifact.deployType
+		}
+		def file = new File("$tempLoadDir/$relativeFilePath/$fileName")
+
+		def (directory, relativeFileName) = extractDirectoryAndFile(file.toPath().toString())
+		new File(directory).mkdirs()
+
+
+		if (deployableArtifact.artifactType.equals("zFSFile")) {
+			def originalFile = new File(container + "/" + deployableArtifact.file)
+			println "\tCopy '${originalFile.toPath()}' to '${file.toPath()}'"
+			try {
+				Files.copy(originalFile.toPath(), file.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
+			} catch (IOException exception) {
+				println "!* [ERROR] Copy failed: an error occurred when copying '${originalFile.toPath()}' to '${file.toPath()}'"
+				rc = Math.max(rc, 1)
+			}
+		} else if  (deployableArtifact.artifactType.equals("DatasetMember")) {
+			// set copyMode based on last level qualifier
+			currentCopyMode = copyModeMap[container.replaceAll(/.*\.([^.]*)/, "\$1")]
+			if (currentCopyMode != null) {
+				if (ZFile.exists("//'$container(${deployableArtifact.file})'")) {
+					// Copy outputs to HFS
+					CopyToHFS copy = new CopyToHFS()
+					copy.setCopyMode(DBBConstants.CopyMode.valueOf(currentCopyMode))
+					copy.setDataset(container)
+
+					println "\tCopy '$container(${deployableArtifact.file})' to '$tempLoadDir/$relativeFilePath/$fileName' with DBB Copymode '$currentCopyMode'"
+					copy.dataset(container).member(deployableArtifact.file).file(file).execute()
+
+					// Tagging binary files
+					if (currentCopyMode == CopyMode.BINARY || currentCopyMode == CopyMode.LOAD) {
+						StringBuffer stdout = new StringBuffer()
+						StringBuffer stderr = new StringBuffer()
+						Process process = "chtag -b $file".execute()
+						process.waitForProcessOutput(stdout, stderr)
+						if (stderr){
+							println ("*! stderr : $stderr")
+							println ("*! stdout : $stdout")
+						}
+					}
+
+					// Append record to Wazi Deploy Application Manifest
+					if (wdManifestGeneratorUtilities && props.generateWaziDeployAppManifest && props.generateWaziDeployAppManifest.toBoolean()) {
+							wdManifestGeneratorUtilities.appendArtifactToManifest(deployableArtifact, "$relativeFilePath/$fileName", record, dependencySetRecord, propertiesRecord)
+					}
+
+				} else {
+					println "*! [ERROR] Copy failed: The file '$container(${deployableArtifact.file})' doesn't exist."
+					rc = Math.max(rc, 1)
+				}
+			} else {
+				println "*! [ERROR] Copy failed: The file '$container(${deployableArtifact.file})' could not be copied due to missing mapping."
+				rc = Math.max(rc, 1)
+			}
+		} else if  (deployableArtifact.artifactType.equals("DatasetMemberDelete")) {
+				// generate delete instruction for Wazi Deploy
+				if (wdManifestGeneratorUtilities && props.generateWaziDeployAppManifest && props.generateWaziDeployAppManifest.toBoolean()) {
+					wdManifestGeneratorUtilities.appendArtifactDeletionToManifest(deployableArtifact, "$relativeFilePath/$fileName", record, propertiesRecord)
+				}
+		}
+
+
+		if (props.generateSBOM && props.generateSBOM.toBoolean() && rc == 0) {
+			sbomUtilities.addEntryToSBOM(deployableArtifact, info)
+		}
+	}
+}
 
 /**
  * parse data set name and member name
@@ -1054,17 +1112,21 @@ def checkBinaryInterfaces(File tempLoadDir, applicationDescriptor) {
 	if (binaryInternalInterfaces) {
 		binaryInterfaces.addAll(binaryInternalInterfaces)
 	}
-	ArrayList<String> missingBinaryInterfaces = new ArrayList<String>() 
+	
 	binaryInterfaces.each { binaryInterface ->
 		String sourceFileName = Paths.get(binaryInterface).getFileName().toString()
-		String expectedFileName = "$includeSubfolder/bin/" + sourceFileName.split("\\.")[0].toUpperCase() + ".OBJ"
+		String member = sourceFileName.split("\\.")[0].toUpperCase()
+		
+		// shared
+		String expectedFileName = "$includeSubfolder/bin/" + member + ".OBJ"
 		File expectedInterface = new File("${tempLoadDir.getAbsolutePath()}/$expectedFileName")
-		if (!expectedInterface.exists()) {
-			missingBinaryInterfaces.add(expectedFileName)
+		// private
+		String expectedFileNamePrivate = "$internalSubfolder/bin/" + member + ".OBJ"
+		File expectedInterfacePrivate = new File("${tempLoadDir.getAbsolutePath()}/$expectedFileNamePrivate")
+		
+		if (!(expectedInterface.exists() || expectedInterfacePrivate.exists())) { //  not found
+			println("*! [WARNING] Binary interface for $member not found in interface folders. Tar not exposing all interfaces.")
 		}
-	}
-	if (missingBinaryInterfaces.size() > 0) {
-		println("*! [WARNING] Some binary interfaces are missing in the current archive: ${missingBinaryInterfaces}.")
 	}
 }
 

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -561,7 +561,7 @@ if (rc == 0) {
 			} else {
 				// grouping of build outputs for shared and generated source only available via Application Descriptor
 				skippedDeployableOutputs = buildOutputsMap.findAll { deployableArtifact, info ->
-					(derivedInterfacesDeployTypes.contains(deployableArtifact.deployType) || publicInterfacesDeployTypes.contains(deployableArtifact.deployType))
+					((derivedInterfacesDeployTypes && derivedInterfacesDeployTypes.contains(deployableArtifact.deployType)) || (publicInterfacesDeployTypes && publicInterfacesDeployTypes.contains(deployableArtifact.deployType)))
 				}
 				if (skippedDeployableOutputs) {
 					println("** Number of skipped build outputs: ${skippedDeployableOutputs.size()}")

--- a/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
+++ b/Pipeline/PackageBuildOutputs/PackageBuildOutputs.groovy
@@ -561,7 +561,7 @@ if (rc == 0) {
 			} else {
 				// grouping of build outputs for shared and generated source only available via Application Descriptor
 				skippedDeployableOutputs = buildOutputsMap.findAll { deployableArtifact, info ->
-					(generated.contains(deployableArtifact.deployType) || shared.contains(deployableArtifact.deployType))
+					(derivedInterfacesDeployTypes.contains(deployableArtifact.deployType) || publicInterfacesDeployTypes.contains(deployableArtifact.deployType))
 				}
 				if (skippedDeployableOutputs) {
 					println("** Number of skipped build outputs: ${skippedDeployableOutputs.size()}")

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -14,6 +14,48 @@ copyModeMap = ["COPYBOOK": "TEXT", "COPY": "TEXT", "DBRM": "BINARY", "LOAD": "LO
 #
 # deployTypesFilter=
 
+# Comma-separated list of deployTypes that describe >public interfaces<
+# that consuming applications pull into their build workspace as a build
+# dependency.
+#
+# Along with the the usage definition 'service interface' in the
+# 'Application Descriptor', these outputs will be made
+# available in a dedicated sub folder of the tar file, that
+# applications that need these modules as a build dependency
+# can include into their build scope/workspace.
+#
+# These deployTypes are excluded from being added to the /bin folder
+# that contains the deployable outputs.
+#
+# This is specifically useful for applications that provide object modules
+# of statically called submodules to other applications.
+# It does not effect modules that are called dynamically.
+publicInterfaces=OBJ
+
+# Comma-separated list of deployTypes that describe derived build outputs
+# that represent >private interfaces< that are required internally for by
+# the application 
+#
+# Along with the required usage definition in the
+# 'Application Descriptor', these files will be made available
+# in a dedicated sub folder of the tar file, that
+# can then be included as a baseline package.
+#
+# These deployTypes are excluded from being added to the /bin folder
+# that contains the deployable outputs.
+# 
+# This is useful for applications with static calls to provide object modules
+# of statically called submodules or generated source code such as 
+# generated copybooks for BMS or DCLgen files for subsequent builds.
+internalInterfaces=OBJ,BMSCOPY
+
+# Publish source code interfaces that are declared as 'shared/public' in the
+# 'Application Descriptor' into dedicated subfolder for consumption by 
+# applications that depend this application.
+# The packaging process retrieves the files directly from the 
+# checked out Git repository.
+publishInterfaces=true
+
 # Comma-separated list of files/patterns from the USS build workspace. (Optional)
 #  Please note that the cli option `includeLogs` overwrites this setting
 #  Sample: includeLogs = *.log,*.xml

--- a/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
+++ b/Pipeline/PackageBuildOutputs/packageBuildOutputs.properties
@@ -70,7 +70,7 @@ addExtension=true
 # Boolean setting to define if the Wazi Deploy Application Manifest file should be generated
 #  Please note that the cli option `generateWaziDeployAppManifest` can override this setting and activate it.
 #  Default: false
-generateWaziDeployAppManifest=false
+generateWaziDeployAppManifest=true
 
 # Boolean setting to define if SBOM based on cycloneDX should be generated
 #  Please note that the cli option `generateSBOM` can override this setting and activate it.

--- a/Pipeline/PackageBuildOutputs/utilities/WaziDeployManifestGenerator.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/WaziDeployManifestGenerator.groovy
@@ -2,6 +2,7 @@ import groovy.transform.*
 import groovy.yaml.YamlBuilder
 import groovy.yaml.YamlSlurper
 import com.ibm.dbb.build.report.records.*
+import com.ibm.dbb.dependency.*
 
 /*
  * This is a utility method to generate the Wazi Deploy Application Manifest file  
@@ -87,6 +88,21 @@ def appendArtifactToManifest(DeployableArtifact deployableArtifact, String path,
 			}
 		}
 	}
+
+	if (dependencySetRecord) {
+
+		// init the dependency set object
+		DependencySet dependencySet = new DependencySet()
+
+		dependencySetRecord.getAllDependencies().each { PhysicalDependency pDep ->
+			// add the dependencies to the arraylist
+			dependencySet.value.add(pDep)
+		}
+
+		artifact.properties.add(dependencySet)
+
+	}
+
 	// add type
 	artifact.type = deployableArtifact.deployType
 
@@ -207,11 +223,37 @@ def appendArtifactDeletionToManifest(DeployableArtifact deployableArtifact, Stri
 
 }
 
+/**
+ * Set scm info for application manifest
+ */
 
 def setScmInfo(HashMap<String, String> scmInfoMap) {
 	wdManifest.metadata.annotations.scmInfo = new ScmInfo()
 	scmInfoMap.each { k, v ->
 		wdManifest.metadata.annotations.scmInfo."$k" = v
+	}
+}
+
+/**
+ * Set package info for application manifest
+ */
+
+def setPackageInfo(HashMap<String, String> packageInfoMap) {
+	wdManifest.metadata.annotations.packageInfo = new PackageInfo()
+	packageInfoMap.each { k, v ->
+		wdManifest.metadata.annotations.packageInfo."$k" = v
+	}
+}
+
+/**
+ * Set external dependencies to metadata/annotations/external_dependencies 
+ */
+
+def setExternalDependencies(File externalDependenciesEvidenceFile) {
+	def yamlSlurper = new YamlSlurper()
+	if (externalDependenciesEvidenceFile.exists()) {
+		ArrayList<ExternalDependency> externalDependenciesEvidences = yamlSlurper.parse(externalDependenciesEvidenceFile)
+		wdManifest.metadata.annotations.external_dependencies = externalDependenciesEvidences
 	}
 }
 
@@ -298,6 +340,8 @@ class Annotations {
 	String creationTimestamp
 	ScmInfo scmInfo
 	PackageInfo packageInfo
+	ArrayList<ExternalDependency> external_dependencies
+	ArrayList buildInfo
 }
 
 class ScmInfo {
@@ -310,7 +354,7 @@ class ScmInfo {
 class PackageInfo {
 	String name
 	String description
-	Properties properties
+	//Properties properties
 	String uri
 	String type
 }
@@ -324,6 +368,26 @@ class Artifact {
 }
 
 class ElementProperty {
+	String key
+	String value
+}
+class DependencySet{
+	String key = "dependency_set"
+	ArrayList<PhysicalDependency> value = new ArrayList<>()
+}
+
+/**
+ * * 
+ * External Dependencies
+ */
+
+class ExternalDependency {
+	String name
+	String type
+	HashSet<Property> properties = new HashSet<>()
+}
+
+class Property {
 	String key
 	String value
 }

--- a/Pipeline/PackageBuildOutputs/utilities/applicationDescriptorUtils.groovy
+++ b/Pipeline/PackageBuildOutputs/utilities/applicationDescriptorUtils.groovy
@@ -283,7 +283,7 @@ def getFileUsage(ApplicationDescriptor applicationDescriptor, String sourceGroup
 						println("*! [WARNING] Multiple files found matching '${name}'. Skipping search.")
 						return null
 					} else {
-						println("*! [WARNING] No file found matching '${name}'. Skipping search.")
+						println("*! [WARNING] No file reference found in application descripor matching '${name}'. Skipping search.")
 						return null
           }
 				} else {


### PR DESCRIPTION
Hi @M-DLB ,

based on your work, I have continued on your implementation and added:

* refined classification to have 
   * `/bin` - the deployable outputs
   * `/public` - the components that other applications can consume in their build
   *  `/private` - derived build outputs that the application itself need (submodules and bms copybooks, etc)
(names are just a matter of change).

* managing the codepages for source code interfaces - see [comment](https://github.com/IBM/dbb/pull/282#discussion_r1825502583)

* exposure of properties allowing easier customisation